### PR TITLE
Improve useability of the anomilies functionality allowing the user t…

### DIFF
--- a/internal/api/web/app.js
+++ b/internal/api/web/app.js
@@ -14,6 +14,36 @@ const packetLabels = [
 /** @type {Cache} */
 const cache = {};
 
+/** @type {boolean} */
+let paused = false;
+
+/**
+ * Collect the summary text of every open <details> inside a container.
+ * @param {Element} container
+ * @returns {Set<string>}
+ */
+function saveDetailsState(container) {
+  const open = new Set();
+  container.querySelectorAll("details[open]").forEach((d) => {
+    const s = d.querySelector("summary");
+    if (s) open.add(s.textContent.trim());
+  });
+  return open;
+}
+
+/**
+ * Re-open <details> whose summary text is in the saved set.
+ * @param {Element} container
+ * @param {Set<string>} open
+ */
+function restoreDetailsState(container, open) {
+  if (!open.size) return;
+  container.querySelectorAll("details").forEach((d) => {
+    const s = d.querySelector("summary");
+    if (s && open.has(s.textContent.trim())) d.open = true;
+  });
+}
+
 function escapeHtml(s) {
   return String(s)
     .replaceAll("&", "&amp;")
@@ -273,6 +303,20 @@ function renderMapTable(title, obj) {
   return `<h3>${escapeHtml(title)}</h3><table class="map-table"><thead><tr><th>Name</th><th>Count</th></tr></thead><tbody>${rows}</tbody></table>`;
 }
 
+/** @type {{ col: string, dir: 1 | -1 }} */
+let devicesSort = { col: "last_seen", dir: -1 };
+
+function sortDevices(devices) {
+  const { col, dir } = devicesSort;
+  return [...devices].sort((a, b) => {
+    const av = a[col] ?? "";
+    const bv = b[col] ?? "";
+    if (av < bv) return -dir;
+    if (av > bv) return dir;
+    return (a.mac || "").localeCompare(b.mac || ""); // stable tie-break by MAC
+  });
+}
+
 function renderDevicesPage() {
   const root = document.getElementById("devices-browser");
   if (!root) return;
@@ -285,7 +329,30 @@ function renderDevicesPage() {
     root.innerHTML = "<p class='muted'>No devices yet.</p>";
     return;
   }
-  const rows = devices
+
+  const savedScrollY = window.scrollY;
+
+  const colDefs = [
+    ["mac", "MAC"],
+    ["ip", "IP"],
+    ["vendor", "Vendor"],
+    ["dns_queries", "DNS"],
+    ["http_requests", "HTTP"],
+    ["tls_connections", "TLS"],
+    ["last_seen", "Last seen"],
+  ];
+
+  const sortedDevices = sortDevices(devices);
+
+  const headers = colDefs
+    .map(([col, label]) => {
+      const active = devicesSort.col === col;
+      const arrow = active ? (devicesSort.dir === 1 ? " ▲" : " ▼") : "";
+      return `<th class="sortable${active ? " sort-active" : ""}" data-col="${col}">${label}${arrow}</th>`;
+    })
+    .join("");
+
+  const rows = sortedDevices
     .map((d) => {
       const mac = escapeHtml(d.mac);
       return `<tr>
@@ -299,9 +366,28 @@ function renderDevicesPage() {
       </tr>`;
     })
     .join("");
-  root.innerHTML = `<table class="device-table">
-    <thead><tr><th>MAC</th><th>IP</th><th>Vendor</th><th>DNS</th><th>HTTP</th><th>TLS</th><th>Last seen</th></tr></thead>
+
+  root.innerHTML = `<table class="device-table sortable-table">
+    <thead><tr>${headers}</tr></thead>
     <tbody>${rows}</tbody></table>`;
+
+  // Wire up header clicks for sorting
+  root.querySelectorAll("th.sortable").forEach((th) => {
+    th.style.cursor = "pointer";
+    th.addEventListener("click", () => {
+      const col = th.dataset.col;
+      if (devicesSort.col === col) {
+        devicesSort.dir = /** @type {1 | -1} */ (devicesSort.dir * -1);
+      } else {
+        devicesSort.col = col;
+        devicesSort.dir = col === "last_seen" ? -1 : 1;
+      }
+      renderDevicesPage();
+    });
+  });
+
+  // Restore scroll position so the view doesn't jump on each refresh
+  window.scrollTo({ top: savedScrollY, behavior: "instant" });
 }
 
 function renderDevicePage(mac) {
@@ -406,6 +492,11 @@ function renderAnomaliesPage() {
   const contrib = document.getElementById("anomaly-last-contrib");
   const list = document.getElementById("anomaly-full-alerts");
   if (!list) return;
+
+  // Preserve which <details> the user has expanded before re-rendering
+  const openInsight = saveDetailsState(document.getElementById("anomaly-full-insight") || document.createElement("div"));
+  const openAlerts = saveDetailsState(list);
+
   renderAnomalyPanel(snap, {
     status: "anomaly-full-status",
     insight: "anomaly-full-insight",
@@ -413,6 +504,10 @@ function renderAnomaliesPage() {
     alerts: "anomaly-full-alerts",
     maxAlerts: 200,
   });
+
+  restoreDetailsState(document.getElementById("anomaly-full-insight") || document.createElement("div"), openInsight);
+  restoreDetailsState(list, openAlerts);
+
   if (!contrib) return;
   if (snap && (snap.last_contributions || []).length) {
     const rows = snap.last_contributions
@@ -476,7 +571,31 @@ async function refreshData() {
 
 async function tick() {
   await refreshData();
-  renderCurrentRoute();
+  if (!paused) {
+    renderCurrentRoute();
+  }
+}
+
+function updatePausedIndicators() {
+  const devNote = document.getElementById("devices-paused-note");
+  const anomNote = document.getElementById("anomalies-paused-note");
+  if (devNote) devNote.hidden = !paused;
+  if (anomNote) anomNote.hidden = !paused;
+}
+
+function setupPauseToggle() {
+  const btn = document.getElementById("pause-toggle");
+  if (!btn) return;
+  btn.addEventListener("click", () => {
+    paused = !paused;
+    btn.textContent = paused ? "Resume Updates" : "Pause Updates";
+    btn.classList.toggle("is-paused", paused);
+    updatePausedIndicators();
+    if (!paused) {
+      // Immediately refresh so the user sees current data
+      tick();
+    }
+  });
 }
 
 function setupThemeToggle() {
@@ -505,6 +624,7 @@ function setupRouter() {
 }
 
 setupThemeToggle();
+setupPauseToggle();
 setupRouter();
 tick();
 setInterval(tick, 3000);

--- a/internal/api/web/index.html
+++ b/internal/api/web/index.html
@@ -18,9 +18,14 @@
         <p class="eyebrow">Network Guardian</p>
         <h1>Cerberus Control Room</h1>
       </div>
-      <button id="theme-toggle" class="toggle" type="button" aria-label="Toggle theme">
-        Dark Mode
-      </button>
+      <div class="header-controls">
+        <button id="pause-toggle" class="toggle toggle-pause" type="button" aria-label="Pause live updates">
+          Pause Updates
+        </button>
+        <button id="theme-toggle" class="toggle" type="button" aria-label="Toggle theme">
+          Dark Mode
+        </button>
+      </div>
     </header>
 
     <nav class="app-nav" aria-label="Main">
@@ -83,7 +88,7 @@
       <div class="page-inner">
         <section class="panel">
           <h2>All devices</h2>
-          <p class="muted">Select a device for full telemetry captured for that MAC.</p>
+          <p class="muted">Select a device for full telemetry captured for that MAC. <span id="devices-paused-note" class="paused-badge" hidden>Updates paused</span></p>
           <div id="devices-browser" class="detail-browser"></div>
         </section>
       </div>
@@ -115,7 +120,7 @@
     <div id="page-anomalies" class="page">
       <div class="page-inner">
         <section class="panel">
-          <h2>Anomaly detection</h2>
+          <h2>Anomaly detection <span id="anomalies-paused-note" class="paused-badge" hidden>Updates paused</span></h2>
           <p id="anomaly-full-status" class="muted"></p>
           <p id="anomaly-full-insight" class="anomaly-insight muted"></p>
           <div id="anomaly-full-metrics" class="stats-grid compact"></div>

--- a/internal/api/web/styles.css
+++ b/internal/api/web/styles.css
@@ -68,6 +68,13 @@ body {
   color: var(--text-soft);
 }
 
+.header-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+}
+
 .toggle {
   border: 1px solid var(--line);
   border-radius: 999px;
@@ -76,6 +83,32 @@ body {
   padding: 10px 16px;
   min-height: 44px;
   cursor: pointer;
+}
+
+.toggle-pause.is-paused {
+  background: var(--accent);
+  color: #fff;
+  border-color: var(--accent);
+}
+
+.paused-badge {
+  display: inline-block;
+  background: var(--accent);
+  color: #fff;
+  font-size: 0.75rem;
+  font-weight: 700;
+  border-radius: 999px;
+  padding: 2px 10px;
+  vertical-align: middle;
+  margin-left: 8px;
+}
+
+th.sortable:hover {
+  text-decoration: underline;
+}
+
+th.sort-active {
+  color: var(--accent);
 }
 
 .app-nav {


### PR DESCRIPTION
## What does this PR do?
Fixes two UX issues caused by the 3-second full-page re-render cycle resetting UI state while the user is actively reading.

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Other (please describe):

**Anomalies page:** Expanding the "Technical details" `<details>` block on any anomaly alert would immediately collapse on the next refresh tick, making the content unreadable.

**All devices page:** The table had no stable sort order, so rows shuffled every 3 seconds. Scroll position was also lost on each tick, making it impossible to track a specific device while browsing.

**Changes made:**
- Added a **Pause / Resume Updates** button to the header. When paused, data is still fetched in the background but the UI is not re-rendered until the user resumes. A "Updates paused" badge appears on the affected pages.
- `saveDetailsState()` / `restoreDetailsState()` — capture which `<details>` elements are open before each re-render and re-open them afterward, so expanded anomaly items survive refresh cycles.
- Devices table now has **clickable sortable column headers** with ▲/▼ indicators. Default sort is last-seen descending and persists across ticks so row order never spontaneously changes.
- `window.scrollY` is saved and restored on each devices render to prevent the view jumping to the top.

---

## How has this been tested?

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing
- [ ] Not applicable

Details:
```
1. Navigate to Anomalies page
2. Expand "Technical details" on any anomaly alert
3. Wait for next refresh tick — details block remains open
4. Navigate to All devices page
5. Scroll down — position is maintained across refresh ticks
6. Click a column header to sort — order is stable across ticks
7. Click "Pause Updates" — badge appears, UI freezes, data still fetches
8. Click "Resume Updates" — UI immediately re-renders with latest data
```

---

## Screenshots / Logs (if applicable)

<!-- Add screenshots, logs, or API outputs -->

---

## Breaking changes

- [ ] Yes
- [x] No

---

## Related issues

Fixes #<!-- anomaly details collapse issue -->
Related to #<!-- device table sort/scroll issue -->

---

## Checklist

- [x] Code follows project conventions
- [ ] Tests added/updated where necessary
- [ ] Documentation updated (if needed)
- [x] No sensitive data included
- [ ] CI passes locally (`make test` / test.sh)

---

## Notes for reviewers

- `saveDetailsState` uses `<summary>` text as the identity key. If two anomaly alerts share an identical summary string (same second timestamp), both would be re-opened — acceptable edge case given event granularity.
- The `cursor: pointer` on `th.sortable` is currently set via inline JS style inside `renderDevicesPage`; this is consistent with the existing pattern of wiring up events after `innerHTML` assignment but could be moved to CSS if preferred.
- Pause state is in-memory only — refreshing the page always resumes live updates.