### PR TITLE
feat: detect rogue DHCP, rogue IPv6 RA, and gateway MAC change

### DIFF
--- a/internal/models/types.go
+++ b/internal/models/types.go
@@ -126,6 +126,13 @@ type AlertRuleConfig struct {
 	MaxDNSQueriesPerDevice int `json:"max_dns_queries_per_device"`
 	MaxTCPConnections      int `json:"max_tcp_connections"`
 	MaxUniqueTargets       int `json:"max_unique_targets"`
+	// KnownGoodDHCPServers seeds the rogue-DHCP baseline with legitimate server IPs
+	// (HA pairs, dual-stack routers). Any DHCP reply from a source not in this list
+	// and not the first-seen server triggers a rogue_dhcp_server alert.
+	KnownGoodDHCPServers []string `json:"known_good_dhcp_servers,omitempty"`
+	// KnownGoodRARouters seeds the rogue-RA baseline with legitimate IPv6 router
+	// link-local addresses. Same first-seen-wins logic as DHCP otherwise.
+	KnownGoodRARouters []string `json:"known_good_ra_routers,omitempty"`
 }
 
 type AlertEvent struct {

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -30,6 +30,7 @@ type NetworkMonitor struct {
 	alerts         []models.AlertEvent
 	alertRuleState map[string]bool
 	alertConfig    models.AlertRuleConfig
+	baselines      *securityBaselines
 	anomaly        *anomalyDetector
 	geoipDB        *geoip2.Reader
 	localSubnet    *net.IPNet
@@ -96,6 +97,7 @@ func NewNetworkMonitor(cacheSize int, dbPath string) (*NetworkMonitor, error) {
 		anomaly:     newAnomalyDetector(),
 		localSubnet: localSubnet,
 	}
+	nm.baselines = newSecurityBaselines(nm.alertConfig)
 
 	go nm.persistWorker()
 	go nm.newDeviceNotifier()
@@ -553,6 +555,7 @@ func (nm *NetworkMonitor) TrackEvent(evt *models.NetworkEvent) {
 	// Update cache
 	nm.Cache.Add(srcMAC, device)
 	nm.evaluateAlerts(device)
+	nm.checkSecurityBaselines(device, evt, srcIP, trafficType)
 	nm.anomaly.observe(time.Now(), evt, srcMAC)
 
 	// Notify if new device
@@ -570,6 +573,20 @@ func (nm *NetworkMonitor) GetAnomalySnapshot() models.AnomalySnapshot {
 		return models.AnomalySnapshot{Status: "disabled"}
 	}
 	return nm.anomaly.status()
+}
+
+func (nm *NetworkMonitor) checkSecurityBaselines(device *models.DeviceInfo, evt *models.NetworkEvent, srcIP string, trafficType models.TrafficType) {
+	if nm.baselines == nil || device == nil {
+		return
+	}
+	switch {
+	case trafficType == models.TrafficUDPDHCP:
+		nm.baselines.checkDHCP(nm, device, evt, srcIP)
+	case evt.EventType == models.EVENT_TYPE_ICMP && evt.IsIPv6 == 1:
+		nm.baselines.checkRA(nm, device, evt, srcIP)
+	case evt.EventType == models.EVENT_TYPE_ARP:
+		nm.baselines.checkARP(nm, device, evt, srcIP)
+	}
 }
 
 func (nm *NetworkMonitor) evaluateAlerts(device *models.DeviceInfo) {

--- a/internal/monitor/security_baselines.go
+++ b/internal/monitor/security_baselines.go
@@ -1,0 +1,133 @@
+package monitor
+
+import (
+	"fmt"
+
+	"github.com/zrougamed/cerberus/internal/models"
+	"github.com/zrougamed/cerberus/internal/utils"
+)
+
+const (
+	protoICMPv6            uint8 = 58
+	icmpv6TypeRouterAdvert uint8 = 134
+)
+
+// securityBaselines tracks first-seen-wins fingerprints for network infrastructure
+// and fires alerts when later observations contradict the baseline. Covers rogue
+// DHCP servers, rogue IPv6 Router Advertisement sources, and ARP-spoof attempts
+// against DHCP-server IPs.
+//
+// Two modes per protocol:
+//   - strict: baseline seeded from AlertRuleConfig.KnownGood*; anything else alerts.
+//   - learning: empty baseline at startup; the first observed source wins and any
+//     subsequent newcomer alerts.
+type securityBaselines struct {
+	dhcpServers map[string]bool   // server IPv4 -> known good
+	raSources   map[string]bool   // router source IPv6 -> known good
+	serverMACs  map[string]string // DHCP-server IPv4 -> MAC observed when it last replied
+	dhcpStrict  bool
+	raStrict    bool
+}
+
+func newSecurityBaselines(cfg models.AlertRuleConfig) *securityBaselines {
+	b := &securityBaselines{
+		dhcpServers: make(map[string]bool),
+		raSources:   make(map[string]bool),
+		serverMACs:  make(map[string]string),
+		dhcpStrict:  len(cfg.KnownGoodDHCPServers) > 0,
+		raStrict:    len(cfg.KnownGoodRARouters) > 0,
+	}
+	for _, ip := range cfg.KnownGoodDHCPServers {
+		b.dhcpServers[ip] = true
+	}
+	for _, ip := range cfg.KnownGoodRARouters {
+		b.raSources[ip] = true
+	}
+	return b
+}
+
+// checkDHCP inspects UDP traffic already classified as DHCP. A BOOTREPLY (op=2)
+// identifies the sender as a DHCP server. Also records the server IP -> MAC
+// binding so subsequent ARP replies for that IP can be checked for spoofing.
+// The MAC binding is seeded once on first observation; a later DHCP reply from
+// the same IP with a different MAC fires gateway_mac_changed rather than
+// silently overwriting the baseline.
+func (b *securityBaselines) checkDHCP(nm *NetworkMonitor, device *models.DeviceInfo, evt *models.NetworkEvent, srcIP string) {
+	if !utils.IsDHCPServerReply(evt.L7Payload) {
+		return
+	}
+	if srcIP == "" || srcIP == "0.0.0.0" {
+		return
+	}
+	if b.dhcpServers[srcIP] {
+		b.recordServerMAC(nm, device, srcIP)
+		return
+	}
+	if !b.dhcpStrict && len(b.dhcpServers) == 0 {
+		b.dhcpServers[srcIP] = true
+		b.serverMACs[srcIP] = device.MAC
+		return
+	}
+	nm.fireAlertIfNeeded(device, "rogue_dhcp_server", true, "high",
+		fmt.Sprintf("Rogue DHCP server reply from %s (%s)", srcIP, device.MAC))
+}
+
+// recordServerMAC seeds the server IP -> MAC binding on first observation. If a
+// binding already exists and the new MAC differs, fires gateway_mac_changed
+// instead of overwriting, so a spoofer cannot poison the ARP-spoof baseline by
+// simply sending one DHCP reply from the legitimate server's IP.
+func (b *securityBaselines) recordServerMAC(nm *NetworkMonitor, device *models.DeviceInfo, srcIP string) {
+	existing, ok := b.serverMACs[srcIP]
+	if !ok {
+		b.serverMACs[srcIP] = device.MAC
+		return
+	}
+	if existing == device.MAC {
+		return
+	}
+	nm.fireAlertIfNeeded(device, "gateway_mac_changed", true, "high",
+		fmt.Sprintf("DHCP server %s MAC changed from %s to %s", srcIP, existing, device.MAC))
+}
+
+// checkRA inspects ICMPv6 events for Router Advertisement (type 134). First-seen
+// source becomes baseline unless strict mode is in effect.
+func (b *securityBaselines) checkRA(nm *NetworkMonitor, device *models.DeviceInfo, evt *models.NetworkEvent, srcIP string) {
+	if evt.Protocol != protoICMPv6 || evt.ICMPType != icmpv6TypeRouterAdvert {
+		return
+	}
+	if srcIP == "" {
+		return
+	}
+	if b.raSources[srcIP] {
+		return
+	}
+	if !b.raStrict && len(b.raSources) == 0 {
+		b.raSources[srcIP] = true
+		return
+	}
+	nm.fireAlertIfNeeded(device, "rogue_ipv6_ra_source", true, "high",
+		fmt.Sprintf("Rogue IPv6 Router Advertisement from %s (%s)", srcIP, device.MAC))
+}
+
+// checkARP fires gateway_mac_changed when an ARP reply claims a DHCP-server IP
+// with a MAC different from the one previously recorded for that server. The
+// ARP body's sender hardware address (arp_sha) is used rather than the Ethernet
+// source MAC, since a spoofer may set those independently.
+func (b *securityBaselines) checkARP(nm *NetworkMonitor, device *models.DeviceInfo, evt *models.NetworkEvent, srcIP string) {
+	if evt.EventType != models.EVENT_TYPE_ARP || evt.ArpOp != 2 {
+		return
+	}
+	expected, known := b.serverMACs[srcIP]
+	if !known {
+		return
+	}
+	observed := utils.MacToString(evt.ArpSha)
+	if observed == "" || observed == "00:00:00:00:00:00" {
+		return
+	}
+	if observed == expected {
+		return
+	}
+	nm.fireAlertIfNeeded(device, "gateway_mac_changed", true, "high",
+		fmt.Sprintf("DHCP server %s MAC changed from %s to %s", srcIP, expected, observed))
+}

--- a/internal/monitor/security_baselines_test.go
+++ b/internal/monitor/security_baselines_test.go
@@ -1,0 +1,213 @@
+package monitor
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/zrougamed/cerberus/internal/models"
+)
+
+func newTestMonitor(cfg models.AlertRuleConfig) *NetworkMonitor {
+	nm := &NetworkMonitor{
+		alerts:         make([]models.AlertEvent, 0),
+		alertRuleState: make(map[string]bool),
+		alertConfig:    cfg,
+	}
+	nm.baselines = newSecurityBaselines(cfg)
+	return nm
+}
+
+func dhcpReplyPayload() [models.L7PayloadSize]byte {
+	var p [models.L7PayloadSize]byte
+	p[0] = 2 // BOOTREPLY
+	return p
+}
+
+func TestRogueDHCPLearningMode(t *testing.T) {
+	nm := newTestMonitor(models.AlertRuleConfig{})
+
+	first := &models.DeviceInfo{MAC: "aa:aa:aa:aa:aa:01"}
+	rogue := &models.DeviceInfo{MAC: "bb:bb:bb:bb:bb:02"}
+
+	evt := &models.NetworkEvent{EventType: models.EVENT_TYPE_UDP, L7Payload: dhcpReplyPayload()}
+
+	nm.baselines.checkDHCP(nm, first, evt, "192.168.1.1")
+	if len(nm.alerts) != 0 {
+		t.Fatalf("expected no alerts after first DHCP server, got %d", len(nm.alerts))
+	}
+
+	nm.baselines.checkDHCP(nm, rogue, evt, "192.168.1.99")
+	if len(nm.alerts) != 1 || nm.alerts[0].Rule != "rogue_dhcp_server" {
+		t.Fatalf("expected rogue_dhcp_server alert, got %+v", nm.alerts)
+	}
+	if !strings.Contains(nm.alerts[0].Message, "192.168.1.99") {
+		t.Fatalf("alert message missing rogue IP: %q", nm.alerts[0].Message)
+	}
+}
+
+func TestRogueDHCPStrictMode(t *testing.T) {
+	nm := newTestMonitor(models.AlertRuleConfig{
+		KnownGoodDHCPServers: []string{"192.168.1.1"},
+	})
+
+	good := &models.DeviceInfo{MAC: "aa:aa:aa:aa:aa:01"}
+	rogue := &models.DeviceInfo{MAC: "bb:bb:bb:bb:bb:02"}
+
+	evt := &models.NetworkEvent{EventType: models.EVENT_TYPE_UDP, L7Payload: dhcpReplyPayload()}
+
+	nm.baselines.checkDHCP(nm, good, evt, "192.168.1.1")
+	if len(nm.alerts) != 0 {
+		t.Fatalf("expected no alerts for known-good server, got %d", len(nm.alerts))
+	}
+
+	nm.baselines.checkDHCP(nm, rogue, evt, "192.168.1.2")
+	if len(nm.alerts) != 1 || nm.alerts[0].Rule != "rogue_dhcp_server" {
+		t.Fatalf("expected rogue_dhcp_server alert in strict mode, got %+v", nm.alerts)
+	}
+}
+
+func TestDHCPClientRequestIgnored(t *testing.T) {
+	nm := newTestMonitor(models.AlertRuleConfig{})
+
+	device := &models.DeviceInfo{MAC: "aa:aa:aa:aa:aa:01"}
+	var clientReq [models.L7PayloadSize]byte
+	clientReq[0] = 1 // BOOTREQUEST
+
+	evt := &models.NetworkEvent{EventType: models.EVENT_TYPE_UDP, L7Payload: clientReq}
+	nm.baselines.checkDHCP(nm, device, evt, "0.0.0.0")
+	nm.baselines.checkDHCP(nm, device, evt, "192.168.1.50")
+
+	if len(nm.alerts) != 0 {
+		t.Fatalf("client requests must not seed baseline or alert, got %d alerts", len(nm.alerts))
+	}
+	if len(nm.baselines.dhcpServers) != 0 {
+		t.Fatalf("client requests must not populate dhcpServers, got %d entries", len(nm.baselines.dhcpServers))
+	}
+}
+
+func TestRogueIPv6RouterAdvertisement(t *testing.T) {
+	nm := newTestMonitor(models.AlertRuleConfig{})
+
+	router := &models.DeviceInfo{MAC: "aa:aa:aa:aa:aa:01"}
+	rogue := &models.DeviceInfo{MAC: "bb:bb:bb:bb:bb:02"}
+
+	evt := &models.NetworkEvent{
+		EventType: models.EVENT_TYPE_ICMP,
+		Protocol:  protoICMPv6,
+		ICMPType:  icmpv6TypeRouterAdvert,
+		IsIPv6:    1,
+	}
+
+	nm.baselines.checkRA(nm, router, evt, "fe80::1")
+	if len(nm.alerts) != 0 {
+		t.Fatalf("first RA must not alert, got %d", len(nm.alerts))
+	}
+
+	nm.baselines.checkRA(nm, rogue, evt, "fe80::dead")
+	if len(nm.alerts) != 1 || nm.alerts[0].Rule != "rogue_ipv6_ra_source" {
+		t.Fatalf("expected rogue_ipv6_ra_source alert, got %+v", nm.alerts)
+	}
+}
+
+func TestRouterAdvertNonType134Ignored(t *testing.T) {
+	nm := newTestMonitor(models.AlertRuleConfig{})
+	device := &models.DeviceInfo{MAC: "aa:aa:aa:aa:aa:01"}
+
+	evt := &models.NetworkEvent{
+		EventType: models.EVENT_TYPE_ICMP,
+		Protocol:  protoICMPv6,
+		ICMPType:  135, // Neighbor Solicitation
+		IsIPv6:    1,
+	}
+	nm.baselines.checkRA(nm, device, evt, "fe80::abc")
+	if len(nm.alerts) != 0 || len(nm.baselines.raSources) != 0 {
+		t.Fatalf("non-RA ICMPv6 must be ignored, got %d alerts %d baselines",
+			len(nm.alerts), len(nm.baselines.raSources))
+	}
+}
+
+func TestGatewayMACChanged(t *testing.T) {
+	nm := newTestMonitor(models.AlertRuleConfig{})
+
+	server := &models.DeviceInfo{MAC: "aa:aa:aa:aa:aa:01"}
+	dhcpEvt := &models.NetworkEvent{EventType: models.EVENT_TYPE_UDP, L7Payload: dhcpReplyPayload()}
+	nm.baselines.checkDHCP(nm, server, dhcpEvt, "192.168.1.1")
+
+	// Same MAC in ARP reply: no alert.
+	matchingARP := &models.NetworkEvent{
+		EventType: models.EVENT_TYPE_ARP,
+		ArpOp:     2,
+		ArpSha:    [6]byte{0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0x01},
+	}
+	nm.baselines.checkARP(nm, server, matchingARP, "192.168.1.1")
+	if len(nm.alerts) != 0 {
+		t.Fatalf("matching MAC must not alert, got %d", len(nm.alerts))
+	}
+
+	// Different MAC claiming the same gateway IP: alert.
+	spoofer := &models.DeviceInfo{MAC: "bb:bb:bb:bb:bb:02"}
+	spoofARP := &models.NetworkEvent{
+		EventType: models.EVENT_TYPE_ARP,
+		ArpOp:     2,
+		ArpSha:    [6]byte{0xbb, 0xbb, 0xbb, 0xbb, 0xbb, 0x02},
+	}
+	nm.baselines.checkARP(nm, spoofer, spoofARP, "192.168.1.1")
+	if len(nm.alerts) != 1 || nm.alerts[0].Rule != "gateway_mac_changed" {
+		t.Fatalf("expected gateway_mac_changed alert, got %+v", nm.alerts)
+	}
+}
+
+func TestGatewayMACChangedIgnoresUnknownIP(t *testing.T) {
+	nm := newTestMonitor(models.AlertRuleConfig{})
+	device := &models.DeviceInfo{MAC: "cc:cc:cc:cc:cc:03"}
+
+	evt := &models.NetworkEvent{
+		EventType: models.EVENT_TYPE_ARP,
+		ArpOp:     2,
+		ArpSha:    [6]byte{0xcc, 0xcc, 0xcc, 0xcc, 0xcc, 0x03},
+	}
+	nm.baselines.checkARP(nm, device, evt, "192.168.1.50")
+	if len(nm.alerts) != 0 {
+		t.Fatalf("ARP for non-server IP must not alert, got %d", len(nm.alerts))
+	}
+}
+
+func TestDHCPServerMACChangeFiresGatewayAlert(t *testing.T) {
+	nm := newTestMonitor(models.AlertRuleConfig{})
+
+	original := &models.DeviceInfo{MAC: "aa:aa:aa:aa:aa:01"}
+	imposter := &models.DeviceInfo{MAC: "cc:cc:cc:cc:cc:03"}
+	evt := &models.NetworkEvent{EventType: models.EVENT_TYPE_UDP, L7Payload: dhcpReplyPayload()}
+
+	nm.baselines.checkDHCP(nm, original, evt, "192.168.1.1")
+	if len(nm.alerts) != 0 {
+		t.Fatalf("expected no alerts after first DHCP server, got %d", len(nm.alerts))
+	}
+
+	// Second reply from same server IP but a different MAC must alert, not
+	// silently rebind the baseline.
+	nm.baselines.checkDHCP(nm, imposter, evt, "192.168.1.1")
+	if len(nm.alerts) != 1 || nm.alerts[0].Rule != "gateway_mac_changed" {
+		t.Fatalf("expected gateway_mac_changed alert on DHCP MAC change, got %+v", nm.alerts)
+	}
+	if nm.baselines.serverMACs["192.168.1.1"] != "aa:aa:aa:aa:aa:01" {
+		t.Fatalf("baseline MAC must not be overwritten, got %q",
+			nm.baselines.serverMACs["192.168.1.1"])
+	}
+}
+
+func TestRogueDHCPDedup(t *testing.T) {
+	nm := newTestMonitor(models.AlertRuleConfig{})
+	good := &models.DeviceInfo{MAC: "aa:aa:aa:aa:aa:01"}
+	rogue := &models.DeviceInfo{MAC: "bb:bb:bb:bb:bb:02"}
+	evt := &models.NetworkEvent{EventType: models.EVENT_TYPE_UDP, L7Payload: dhcpReplyPayload()}
+
+	nm.baselines.checkDHCP(nm, good, evt, "192.168.1.1")
+	nm.baselines.checkDHCP(nm, rogue, evt, "192.168.1.99")
+	nm.baselines.checkDHCP(nm, rogue, evt, "192.168.1.99")
+	nm.baselines.checkDHCP(nm, rogue, evt, "192.168.1.99")
+
+	if len(nm.alerts) != 1 {
+		t.Fatalf("rogue server must alert once, got %d", len(nm.alerts))
+	}
+}

--- a/internal/utils/converter.go
+++ b/internal/utils/converter.go
@@ -445,6 +445,13 @@ func TLSVersionFromPayload(payload [models.L7PayloadSize]byte) string {
 	}
 }
 
+// IsDHCPServerReply reports whether the payload looks like a BOOTREPLY (op=2),
+// which is what DHCP servers send (OFFER, ACK, NAK). Client requests are op=1.
+// This is enough to identify a host acting as a DHCP server without parsing options.
+func IsDHCPServerReply(payload [models.L7PayloadSize]byte) bool {
+	return payload[0] == 2
+}
+
 // GetL7Info extracts layer 7 information based on event type and payload
 func GetL7Info(evt *models.NetworkEvent) string {
 	switch evt.EventType {


### PR DESCRIPTION
## What does this PR do?

Adds three passive infrastructure-spoofing checks for the network monitor, addressing the feature request in #4. All checks reuse the existing alert pipeline (`fireAlertIfNeeded`) and surface through `/api/alerts` with no further wiring.

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Other (please describe):

**New alert rules:**

- `rogue_dhcp_server` — fires on a BOOTREPLY (DHCP `op=2`) from a source that is not in the baseline. Baseline is empty by default and seeded by the first server seen (learning mode); if `AlertRuleConfig.KnownGoodDHCPServers` is configured, it becomes a strict allowlist instead.
- `rogue_ipv6_ra_source` — fires on ICMPv6 Router Advertisement (type 134) from a source not in the baseline. Same learning/strict modes via `AlertRuleConfig.KnownGoodRARouters`.
- `gateway_mac_changed` — records the MAC observed for each DHCP-server IP and alerts when (a) an ARP reply claims that IP with a different `arp_sha`, or (b) a later DHCP reply from the same server IP arrives with a different MAC. Uses the ARP body's sender hardware address rather than the Ethernet source MAC, since a spoofer can set those independently.

**Design choices:**

- Userspace-only — no eBPF, no new event types. DHCPv4 (UDP/67-68) is already classified as `UDP_DHCP`; ICMPv6 type 134 already arrives with `evt.ICMPType` set; ARP is already parsed with `arp_sha` available.
- The DHCP "is this a server reply?" check is a one-byte BOOTREPLY (`op=2`) test, not full option parsing. 128-byte L7 capture is sufficient for this; deeper option parsing (lease, gateway, DNS servers) would have required extending the eBPF capture window and is left for a follow-up if anyone needs lease metadata.
- Gateway-IP-MAC binding uses the DHCP server's source IP as a proxy for "the gateway." On home/SMB networks (and most enterprise edges) these are the same device. Avoids parsing DHCP option 3.
- New `AlertRuleConfig` fields use `omitempty` and default to empty slices — fully backward compatible with existing configs.

---

## How has this been tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] Not applicable

Details:

```
gofmt -l .                    # clean
go vet ./...                  # clean
go build ./...                # clean
go test ./... -race -count=1  # all packages PASS

go test ./internal/monitor/ -run 'TestRogue|TestGateway|TestDHCP|TestRouter' -v
=== RUN   TestRogueDHCPLearningMode               --- PASS
=== RUN   TestRogueDHCPStrictMode                 --- PASS
=== RUN   TestDHCPClientRequestIgnored            --- PASS
=== RUN   TestRogueIPv6RouterAdvertisement        --- PASS
=== RUN   TestRouterAdvertNonType134Ignored       --- PASS
=== RUN   TestGatewayMACChanged                   --- PASS
=== RUN   TestGatewayMACChangedIgnoresUnknownIP   --- PASS
=== RUN   TestDHCPServerMACChangeFiresGatewayAlert --- PASS
=== RUN   TestRogueDHCPDedup                      --- PASS
```

Nine tests cover: learning-mode seeding, strict-mode allowlist, client-request rejection, RA type-134 gating, non-type-134 rejection, ARP gateway MAC mismatch, ARP for unknown IP ignored, DHCP-side MAC change detection, and alert dedup.

---

## Breaking changes

- [ ] Yes
- [x] No

`AlertRuleConfig` gains two optional fields; existing configs continue to parse and produce learning-mode behavior.

---

## Related issues

Closes #4

---

## Checklist

- [x] Code follows project conventions
- [x] Tests added/updated where necessary
- [ ] Documentation updated (if needed)
- [x] No sensitive data included
- [x] CI passes locally (`go test ./... -race`)

---

## Notes for reviewers

- **Out of v1 scope:** DHCPv6 (UDP/546-547) is not covered — `classifyUDPTraffic` only matches IPv4 DHCP ports. The same `securityBaselines` struct could be extended later without restructuring.
- **Learning-mode caveat:** if no `KnownGood*` list is configured and a rogue beats the legitimate server to the first packet at startup, the rogue gets seeded as the baseline. This is the inherent risk of learning mode and is what the allowlist fields exist for. Networks with HA DHCP pairs (e.g. VRRP/CARP, redundant routers) should configure `KnownGoodDHCPServers` to avoid both this and false `gateway_mac_changed` alerts on failover.
- The DHCP-side MAC-change check (`recordServerMAC` in `security_baselines.go`) was added to close a bug where a spoofer could send one DHCP reply from the legitimate server's IP with their own MAC and silently rebind the ARP-spoof baseline. There is a regression test for this (`TestDHCPServerMACChangeFiresGatewayAlert`).
- Lock-wise: the new checks run from inside `TrackEvent` under `nm.mu.Lock()`. No additional synchronisation needed; verified clean under `go test -race`.