### PR TITLE
fix: pin gateway IP and flag forwarded traffic

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -9,7 +9,7 @@ Base URL is whatever host/port `CERBERUS_HTTP_ADDR` binds to (default `http://12
 | Path | Description |
 |------|-------------|
 | `GET /api/v1/summary` | Fleet snapshot: packet counters, device count, ranked services/vendors/DNS stats, recent devices, encrypted DNS / TLS version aggregates where computed, correlated-domain hints, **and** fields the Control Room overview expects. Implementation aggregates from current in-memory devices. |
-| `GET /api/v1/devices` | Array of full per-MAC `DeviceInfo`-compatible objects (JSON-tagged fields only). |
+| `GET /api/v1/devices` | Array of full per-MAC `DeviceInfo`-compatible objects (JSON-tagged fields only). Includes `is_gateway` (true once the MAC is observed sourcing IPv4 packets with a non-local source IP) and `forwarded_source_count` (number of such forwarded packets). |
 | `GET /api/v1/alerts` | Array of recent rule-based `AlertEvent` objects (threshold monitor). |
 | `GET /api/v1/anomalies` | Single **anomaly snapshot** object: model status, scores, last features, recent alerts with `summary` (plain) and `detail` (technical), `last_summary` / `last_summary_detail` / `last_contributions`, etc. |
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -62,6 +62,7 @@ type deviceSummaryItem struct {
 	MAC          string    `json:"mac"`
 	IP           string    `json:"ip"`
 	Vendor       string    `json:"vendor"`
+	IsGateway    bool      `json:"is_gateway,omitempty"`
 	FirstSeen    time.Time `json:"first_seen"`
 	LastSeen     time.Time `json:"last_seen"`
 	TCP          int       `json:"tcp"`
@@ -117,6 +118,7 @@ func (s *Server) handleSummary(w http.ResponseWriter, r *http.Request) {
 			MAC:          d.MAC,
 			IP:           d.IP,
 			Vendor:       d.Vendor,
+			IsGateway:    d.IsGateway,
 			FirstSeen:    d.FirstSeen,
 			LastSeen:     d.LastSeen,
 			TCP:          d.TCPConnections,

--- a/internal/api/web/app.js
+++ b/internal/api/web/app.js
@@ -160,15 +160,16 @@ function renderRecentDevices(items) {
     return;
   }
   root.innerHTML = items
-    .map(
-      (d) => `
+    .map((d) => {
+      const gw = d.is_gateway ? ' <span class="badge gateway-badge" title="Acts as a gateway/NAT">GW</span>' : "";
+      return `
       <article class="device">
-        <strong><a href="${deviceHref(d.mac)}">${escapeHtml(d.ip)} · ${escapeHtml(d.vendor || "Unknown")}</a></strong>
+        <strong><a href="${deviceHref(d.mac)}">${escapeHtml(d.ip)} · ${escapeHtml(d.vendor || "Unknown")}</a>${gw}</strong>
         <div class="line"><span>MAC ${escapeHtml(d.mac)}</span><span>DNS ${d.dns_queries}</span></div>
         <div class="line"><span>HTTP ${d.http_requests}</span><span>TLS ${d.tls}</span></div>
       </article>
-    `,
-    )
+    `;
+    })
     .join("");
 }
 
@@ -355,8 +356,9 @@ function renderDevicesPage() {
   const rows = sortedDevices
     .map((d) => {
       const mac = escapeHtml(d.mac);
+      const gw = d.is_gateway ? ' <span class="badge gateway-badge" title="Acts as a gateway/NAT">GW</span>' : "";
       return `<tr>
-        <td><a href="${deviceHref(d.mac)}">${mac}</a></td>
+        <td><a href="${deviceHref(d.mac)}">${mac}</a>${gw}</td>
         <td>${escapeHtml(d.ip || "")}</td>
         <td>${escapeHtml(d.vendor || "")}</td>
         <td>${d.dns_queries ?? 0}</td>
@@ -411,6 +413,8 @@ function renderDevicePage(mac) {
     ["MAC", d.mac],
     ["IP", d.ip],
     ["Vendor", d.vendor],
+    ["Acts as gateway", d.is_gateway ? "Yes" : ""],
+    ["Forwarded packets", d.forwarded_source_count],
     ["Interface", d.interface],
     ["Geo country", d.geo_country],
     ["Geo code", d.geo_country_code],

--- a/internal/api/web/styles.css
+++ b/internal/api/web/styles.css
@@ -487,6 +487,14 @@ h3 {
   font-size: 0.82rem;
 }
 
+.gateway-badge {
+  background: rgba(120, 200, 80, 0.18);
+  color: #3a8c1f;
+  margin-left: 6px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
 @media (min-width: 760px) {
   .layout {
     grid-template-columns: repeat(2, minmax(0, 1fr));

--- a/internal/models/types.go
+++ b/internal/models/types.go
@@ -201,37 +201,44 @@ type AnomalySnapshot struct {
 }
 
 type DeviceInfo struct {
-	MAC                string                `json:"mac"`
-	IP                 string                `json:"ip"`
-	Vendor             string                `json:"vendor"`
-	GeoCountry         string                `json:"geo_country,omitempty"`
-	GeoCountryCode     string                `json:"geo_country_code,omitempty"`
-	GeoCity            string                `json:"geo_city,omitempty"`
-	Interface          string                `json:"interface,omitempty"` // Network interface name (e.g., eth0, wlan0)
-	FirstSeen          time.Time             `json:"first_seen"`
-	LastSeen           time.Time             `json:"last_seen"`
-	RequestCount       int                   `json:"request_count"`
-	ReplyCount         int                   `json:"reply_count"`
-	TCPConnections     int                   `json:"tcp_connections"`
-	UDPConnections     int                   `json:"udp_connections"`
-	ICMPPackets        int                   `json:"icmp_packets"`
-	DNSQueries         int                   `json:"dns_queries"`
-	HTTPRequests       int                   `json:"http_requests"`
-	TLSConnections     int                   `json:"tls_connections"`
-	Targets            []string              `json:"targets"`
-	Services           map[string]int        `json:"services"` // service -> count
-	DNSDomains         map[string]int        `json:"dns_domains,omitempty"`
-	DNSResponseDomains map[string]int        `json:"dns_response_domains,omitempty"`
-	DNSQueryTypes      map[string]int        `json:"dns_query_types,omitempty"`
-	DNSResponseCodes   map[string]int        `json:"dns_response_codes,omitempty"`
-	EncryptedDNS       map[string]int        `json:"encrypted_dns,omitempty"`
-	DNSCorrelated      int                   `json:"dns_correlated_connections,omitempty"`
-	CorrelatedDomains  map[string]int        `json:"correlated_domains,omitempty"`
-	HTTPHosts          map[string]int        `json:"http_hosts,omitempty"`
-	TLSSNIs            map[string]int        `json:"tls_snis,omitempty"`
-	TLSVersions        map[string]int        `json:"tls_versions,omitempty"`
-	RecentDNSQueries   map[string]time.Time  `json:"-"`
-	SeenPatterns       map[string]bool       `json:"-"`
-	TrafficTypeCounts  map[TrafficType]int   `json:"traffic_type_counts"`
-	FlowStats          map[string]*FlowStats `json:"-"` // flowKey -> stats
+	MAC            string `json:"mac"`
+	IP             string `json:"ip"`
+	Vendor         string `json:"vendor"`
+	GeoCountry     string `json:"geo_country,omitempty"`
+	GeoCountryCode string `json:"geo_country_code,omitempty"`
+	GeoCity        string `json:"geo_city,omitempty"`
+	Interface      string `json:"interface,omitempty"` // Network interface name (e.g., eth0, wlan0)
+	// IsGateway is true once we observe this MAC sourcing IPv4 packets whose
+	// L3 source IP is outside any local subnet, i.e. forwarded/NATed traffic.
+	IsGateway bool `json:"is_gateway,omitempty"`
+	// ForwardedSourceCount counts non-ARP IPv4 packets seen from this MAC
+	// whose source IP is not on a local subnet. A non-zero value implies the
+	// device is acting as a router/NAT, not the originator of those packets.
+	ForwardedSourceCount int                   `json:"forwarded_source_count,omitempty"`
+	FirstSeen            time.Time             `json:"first_seen"`
+	LastSeen             time.Time             `json:"last_seen"`
+	RequestCount         int                   `json:"request_count"`
+	ReplyCount           int                   `json:"reply_count"`
+	TCPConnections       int                   `json:"tcp_connections"`
+	UDPConnections       int                   `json:"udp_connections"`
+	ICMPPackets          int                   `json:"icmp_packets"`
+	DNSQueries           int                   `json:"dns_queries"`
+	HTTPRequests         int                   `json:"http_requests"`
+	TLSConnections       int                   `json:"tls_connections"`
+	Targets              []string              `json:"targets"`
+	Services             map[string]int        `json:"services"` // service -> count
+	DNSDomains           map[string]int        `json:"dns_domains,omitempty"`
+	DNSResponseDomains   map[string]int        `json:"dns_response_domains,omitempty"`
+	DNSQueryTypes        map[string]int        `json:"dns_query_types,omitempty"`
+	DNSResponseCodes     map[string]int        `json:"dns_response_codes,omitempty"`
+	EncryptedDNS         map[string]int        `json:"encrypted_dns,omitempty"`
+	DNSCorrelated        int                   `json:"dns_correlated_connections,omitempty"`
+	CorrelatedDomains    map[string]int        `json:"correlated_domains,omitempty"`
+	HTTPHosts            map[string]int        `json:"http_hosts,omitempty"`
+	TLSSNIs              map[string]int        `json:"tls_snis,omitempty"`
+	TLSVersions          map[string]int        `json:"tls_versions,omitempty"`
+	RecentDNSQueries     map[string]time.Time  `json:"-"`
+	SeenPatterns         map[string]bool       `json:"-"`
+	TrafficTypeCounts    map[TrafficType]int   `json:"traffic_type_counts"`
+	FlowStats            map[string]*FlowStats `json:"-"` // flowKey -> stats
 }

--- a/internal/monitor/gateway_test.go
+++ b/internal/monitor/gateway_test.go
@@ -1,0 +1,131 @@
+package monitor
+
+import (
+	"net"
+	"testing"
+
+	"github.com/zrougamed/cerberus/internal/models"
+	"github.com/zrougamed/cerberus/internal/network"
+)
+
+func newGatewayTestMonitor(t *testing.T) *NetworkMonitor {
+	t.Helper()
+	_, lan, err := net.ParseCIDR("192.168.1.0/24")
+	if err != nil {
+		t.Fatalf("parse cidr: %v", err)
+	}
+	return &NetworkMonitor{
+		topology: &network.NetworkTopology{
+			LocalSubnets: []*net.IPNet{lan},
+		},
+	}
+}
+
+func TestUpdateDeviceIPLocalSourceUpdates(t *testing.T) {
+	nm := newGatewayTestMonitor(t)
+	device := &models.DeviceInfo{MAC: "aa:bb:cc:dd:ee:01"}
+	evt := &models.NetworkEvent{EventType: models.EVENT_TYPE_TCP}
+
+	nm.updateDeviceIP(device, evt, "192.168.1.50")
+
+	if device.IP != "192.168.1.50" {
+		t.Fatalf("expected device IP set to LAN source, got %q", device.IP)
+	}
+	if device.IsGateway {
+		t.Fatal("LAN-sourced traffic must not flag device as gateway")
+	}
+	if device.ForwardedSourceCount != 0 {
+		t.Fatalf("forwarded count should stay zero, got %d", device.ForwardedSourceCount)
+	}
+}
+
+func TestUpdateDeviceIPForwardedExternalDoesNotOverwrite(t *testing.T) {
+	nm := newGatewayTestMonitor(t)
+	device := &models.DeviceInfo{MAC: "aa:bb:cc:dd:ee:01", IP: "192.168.1.1"}
+	evt := &models.NetworkEvent{EventType: models.EVENT_TYPE_TCP}
+
+	nm.updateDeviceIP(device, evt, "8.8.8.8")
+	nm.updateDeviceIP(device, evt, "1.1.1.1")
+
+	if device.IP != "192.168.1.1" {
+		t.Fatalf("forwarded external src must not overwrite IP, got %q", device.IP)
+	}
+	if !device.IsGateway {
+		t.Fatal("forwarded external traffic should flag device as gateway")
+	}
+	if device.ForwardedSourceCount != 2 {
+		t.Fatalf("expected forwarded count 2, got %d", device.ForwardedSourceCount)
+	}
+}
+
+func TestUpdateDeviceIPARPAlwaysTrusted(t *testing.T) {
+	nm := newGatewayTestMonitor(t)
+	device := &models.DeviceInfo{MAC: "aa:bb:cc:dd:ee:01", IP: "0.0.0.0"}
+	arpEvt := &models.NetworkEvent{EventType: models.EVENT_TYPE_ARP}
+
+	nm.updateDeviceIP(device, arpEvt, "192.168.1.1")
+	if device.IP != "192.168.1.1" {
+		t.Fatalf("ARP event should set device IP, got %q", device.IP)
+	}
+
+	// ARP must override even when previously poisoned with junk.
+	device.IP = "10.0.0.99"
+	nm.updateDeviceIP(device, arpEvt, "192.168.1.1")
+	if device.IP != "192.168.1.1" {
+		t.Fatalf("ARP must reassert real binding, got %q", device.IP)
+	}
+}
+
+func TestUpdateDeviceIPIgnoresZeroSrc(t *testing.T) {
+	nm := newGatewayTestMonitor(t)
+	device := &models.DeviceInfo{MAC: "aa:bb:cc:dd:ee:01", IP: "192.168.1.50"}
+	evt := &models.NetworkEvent{EventType: models.EVENT_TYPE_UDP}
+
+	nm.updateDeviceIP(device, evt, "0.0.0.0")
+	nm.updateDeviceIP(device, evt, "")
+
+	if device.IP != "192.168.1.50" {
+		t.Fatalf("zero/empty srcIP must be a no-op, got %q", device.IP)
+	}
+	if device.IsGateway || device.ForwardedSourceCount != 0 {
+		t.Fatalf("zero/empty srcIP must not flag gateway, got is_gw=%v count=%d",
+			device.IsGateway, device.ForwardedSourceCount)
+	}
+}
+
+func TestUpdateDeviceIPNoTopologyFallsBackToPrivate(t *testing.T) {
+	nm := &NetworkMonitor{}
+	device := &models.DeviceInfo{MAC: "aa:bb:cc:dd:ee:01"}
+	evt := &models.NetworkEvent{EventType: models.EVENT_TYPE_TCP}
+
+	nm.updateDeviceIP(device, evt, "10.20.30.40")
+	if device.IP != "10.20.30.40" {
+		t.Fatalf("RFC1918 srcIP should be accepted as device IP without topology, got %q", device.IP)
+	}
+
+	device2 := &models.DeviceInfo{MAC: "aa:bb:cc:dd:ee:02", IP: "10.20.30.1"}
+	nm.updateDeviceIP(device2, evt, "8.8.8.8")
+	if device2.IP != "10.20.30.1" {
+		t.Fatalf("public srcIP should not overwrite device IP, got %q", device2.IP)
+	}
+	if !device2.IsGateway || device2.ForwardedSourceCount != 1 {
+		t.Fatalf("public srcIP should flag gateway, got is_gw=%v count=%d",
+			device2.IsGateway, device2.ForwardedSourceCount)
+	}
+}
+
+func TestUpdateDeviceIPIPv6KeepsFirstSeen(t *testing.T) {
+	nm := newGatewayTestMonitor(t)
+	device := &models.DeviceInfo{MAC: "aa:bb:cc:dd:ee:01"}
+	evt := &models.NetworkEvent{EventType: models.EVENT_TYPE_TCP, IsIPv6: 1}
+
+	nm.updateDeviceIP(device, evt, "fe80::1")
+	if device.IP != "fe80::1" {
+		t.Fatalf("first IPv6 srcIP should set device IP, got %q", device.IP)
+	}
+
+	nm.updateDeviceIP(device, evt, "2001:db8::1234")
+	if device.IP != "fe80::1" {
+		t.Fatalf("subsequent IPv6 srcIP should not overwrite, got %q", device.IP)
+	}
+}

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -33,7 +33,7 @@ type NetworkMonitor struct {
 	baselines      *securityBaselines
 	anomaly        *anomalyDetector
 	geoipDB        *geoip2.Reader
-	localSubnet    *net.IPNet
+	topology       *network.NetworkTopology
 	Stats          struct {
 		TotalPackets uint64
 		ArpPackets   uint64
@@ -73,7 +73,10 @@ func NewNetworkMonitor(cacheSize int, dbPath string) (*NetworkMonitor, error) {
 	db.CreateIndex("mac", "*", buntdb.IndexJSON("mac"))
 	db.CreateIndex("last_seen", "*", buntdb.IndexJSON("last_seen"))
 
-	localSubnet := network.DetectLocalSubnet()
+	topology, err := network.DetectNetworkTopology()
+	if err != nil {
+		topology = nil
+	}
 
 	online := databases.OnlineDB()
 	oui, _ := databases.NewOUIDatabase(online)
@@ -94,8 +97,8 @@ func NewNetworkMonitor(cacheSize int, dbPath string) (*NetworkMonitor, error) {
 			// Targets keeps at most 20 unique dst IPs per device; threshold must be < 20 or target_spread never fires.
 			MaxUniqueTargets: 18,
 		},
-		anomaly:     newAnomalyDetector(),
-		localSubnet: localSubnet,
+		anomaly:  newAnomalyDetector(),
+		topology: topology,
 	}
 	nm.baselines = newSecurityBaselines(nm.alertConfig)
 
@@ -267,6 +270,61 @@ func isGeoIPEligible(ipStr string) bool {
 		return false
 	}
 	return true
+}
+
+// updateDeviceIP keeps device.IP pinned to a real LAN address even when a
+// gateway forwards packets whose L3 source is some other host. ARP events are
+// trusted (the eBPF parser puts the ARP sender protocol address in SrcIP);
+// non-ARP IPv4 events only overwrite when srcIP is on a local subnet,
+// otherwise the device is flagged as a gateway and the count bumped.
+func (nm *NetworkMonitor) updateDeviceIP(device *models.DeviceInfo, evt *models.NetworkEvent, srcIP string) {
+	if device == nil || srcIP == "" || srcIP == "0.0.0.0" {
+		return
+	}
+
+	if evt.EventType == models.EVENT_TYPE_ARP {
+		if device.IP != srcIP {
+			device.IP = srcIP
+		}
+		return
+	}
+
+	if evt.IsIPv6 == 1 {
+		if device.IP == "" {
+			device.IP = srcIP
+		}
+		return
+	}
+
+	parsed := net.ParseIP(srcIP)
+	if parsed == nil {
+		return
+	}
+	if nm.isLocalIPv4(parsed) {
+		if device.IP != srcIP {
+			device.IP = srcIP
+		}
+		return
+	}
+
+	device.IsGateway = true
+	device.ForwardedSourceCount++
+}
+
+// isLocalIPv4 reports whether ip belongs to one of the host's directly
+// attached IPv4 subnets. Falls back to net.IP.IsPrivate when topology
+// detection failed at startup so the rule still works on minimal hosts.
+func (nm *NetworkMonitor) isLocalIPv4(ip net.IP) bool {
+	if ip == nil {
+		return false
+	}
+	if nm.topology != nil && nm.topology.IsLocalIP(ip) {
+		return true
+	}
+	if nm.topology == nil {
+		return ip.IsPrivate() || ip.IsLoopback() || ip.IsLinkLocalUnicast()
+	}
+	return false
 }
 
 func (nm *NetworkMonitor) updateGeoForIP(device *models.DeviceInfo, ipStr string) {
@@ -448,9 +506,7 @@ func (nm *NetworkMonitor) TrackEvent(evt *models.NetworkEvent) {
 
 	// Update device info
 	device.LastSeen = time.Now()
-	if device.IP != srcIP && srcIP != "0.0.0.0" {
-		device.IP = srcIP
-	}
+	nm.updateDeviceIP(device, evt, srcIP)
 	nm.updateGeoForIP(device, srcIP)
 
 	device.TrafficTypeCounts[trafficType]++


### PR DESCRIPTION
## Summary
- Stop overwriting `device.IP` with NATed/forwarded source IPs so a gateway entry no longer flips between external addresses.
- Trust ARP events for the gateway's real MAC<->IP binding; non-ARP IPv4 events only update `device.IP` when the source is on a local subnet.
- Add `is_gateway` and `forwarded_source_count` to `DeviceInfo`; surface a GW badge on the overview, devices browser and device detail.

## Context
Fixes #7. As called out on the issue, ARP is already correct because the eBPF parser populates `SrcIP` from the ARP sender protocol address. The bug was that forwarded IPv4 packets re-set the gateway device's IP on every event. The fix uses the existing `network.NetworkTopology` to decide whether a source IP looks local; if it isn't, the packet is forwarded and the device is flagged.

## Test plan
- [x] `go vet ./...` clean
- [x] `gofmt -s -l .` clean
- [x] `go test ./...` passes, including new `internal/monitor/gateway_test.go` cases for: local source updates, external source does not overwrite, ARP overrides, zero/empty src no-op, fallback when topology detection is unavailable, IPv6 keeps first seen.
- [ ] Manual smoke: run `cerberus` behind a gateway, confirm gateway device keeps its LAN IP and shows the GW badge while public peer IPs no longer churn the device entry.