### PR TITLE
feat: surface build version in logs, API, metrics, and dashboard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,7 +231,12 @@ jobs:
 
       - name: Build production Docker image
         run: |
-          docker build -t cerberus:test .
+          COMMIT=$(git rev-parse --short HEAD)
+          BUILD_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          docker build \
+            --build-arg COMMIT="${COMMIT}" \
+            --build-arg BUILD_DATE="${BUILD_DATE}" \
+            -t cerberus:test .
 
       - name: Verify image
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,6 +154,12 @@ jobs:
             type=raw,value=${{ env.RELEASE_TAG }}
             type=raw,value=latest
 
+      - name: Compute build metadata
+        id: build_meta
+        run: |
+          echo "commit=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+          echo "date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
@@ -163,5 +169,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            COMMIT=${{ steps.build_meta.outputs.commit }}
+            BUILD_DATE=${{ steps.build_meta.outputs.date }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,7 @@ RUN apk add --no-cache \
     build-base \
     libbpf-dev \
     linux-headers \
-    make \
-    git
+    make
 
 ENV GOCACHE=/root/.cache/go-build
 ENV GOMODCACHE=/go/pkg/mod
@@ -26,13 +25,16 @@ COPY . .
 # Build eBPF program
 RUN make bpf
 
-# Build Go binary with version metadata stamped via ldflags. Falls back to
-# "unknown" when the build context lacks .git (e.g. CI tarballs).
-RUN COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo unknown) \
-    && BUILD_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ) \
-    && CGO_ENABLED=0 go build \
-        -ldflags="-s -w -X github.com/zrougamed/cerberus/internal/version.Commit=${COMMIT} -X github.com/zrougamed/cerberus/internal/version.Date=${BUILD_DATE}" \
-        -o cerberus cmd/cerberus/main.go
+# Build metadata is passed in from the caller (Makefile / CI workflow). The
+# .git tree is not present in the build context (see .dockerignore), so we
+# never shell out to git here.
+ARG COMMIT=unknown
+ARG BUILD_DATE=unknown
+
+# Build Go binary with version metadata stamped via ldflags.
+RUN CGO_ENABLED=0 go build \
+    -ldflags="-s -w -X github.com/zrougamed/cerberus/internal/version.Commit=${COMMIT} -X github.com/zrougamed/cerberus/internal/version.Date=${BUILD_DATE}" \
+    -o cerberus cmd/cerberus/main.go
 
 # Runtime stage
 FROM alpine:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,13 @@ COPY . .
 # Build eBPF program
 RUN make bpf
 
-# Build Go binary
-RUN CGO_ENABLED=0 go build -ldflags="-s -w" -o cerberus cmd/cerberus/main.go
+# Build Go binary with version metadata stamped via ldflags. Falls back to
+# "unknown" when the build context lacks .git (e.g. CI tarballs).
+RUN COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo unknown) \
+    && BUILD_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ) \
+    && CGO_ENABLED=0 go build \
+        -ldflags="-s -w -X github.com/zrougamed/cerberus/internal/version.Commit=${COMMIT} -X github.com/zrougamed/cerberus/internal/version.Date=${BUILD_DATE}" \
+        -o cerberus cmd/cerberus/main.go
 
 # Runtime stage
 FROM alpine:latest

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,13 @@ BPF_SRC := ebpf/cerberus_tc.c
 GO_SRC := cmd/cerberus/main.go
 BUILD_DIR := build
 
+# Build metadata stamped into the binary via -ldflags -X. Falls back to "unknown"
+# when git is unavailable (e.g. tarball builds).
+VERSION_PKG := github.com/zrougamed/cerberus/internal/version
+COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
+BUILD_DATE := $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
+LDFLAGS := -s -w -X $(VERSION_PKG).Commit=$(COMMIT) -X $(VERSION_PKG).Date=$(BUILD_DATE)
+
 .PHONY: all clean build bpf run deps ci ci-build ci-test docker-build docker-run docker-up docker-down docker-logs docker-web help
 
 all: bpf build
@@ -24,7 +31,7 @@ $(BPF_OBJ): $(BPF_SRC)
 
 # Build Go binary
 build: bpf
-	CGO_ENABLED=0 $(GO) build -ldflags="-s -w" -o build/$(BINARY) $(GO_SRC)
+	CGO_ENABLED=0 $(GO) build -ldflags="$(LDFLAGS)" -o build/$(BINARY) $(GO_SRC)
 
 # Run the program (requires sudo)
 run: all

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,10 @@ deps:
 
 # Docker build
 docker-build:
-	docker build -t cerberus:latest .
+	docker build \
+		--build-arg COMMIT=$(COMMIT) \
+		--build-arg BUILD_DATE=$(BUILD_DATE) \
+		-t cerberus:latest .
 
 # Docker run (privileged for BPF)
 docker-run:

--- a/cmd/cerberus/main.go
+++ b/cmd/cerberus/main.go
@@ -19,9 +19,12 @@ import (
 	"github.com/zrougamed/cerberus/internal/models"
 	"github.com/zrougamed/cerberus/internal/monitor"
 	"github.com/zrougamed/cerberus/internal/utils"
+	"github.com/zrougamed/cerberus/internal/version"
 )
 
 func main() {
+	fmt.Printf("Cerberus %s\n", version.String())
+
 	// Clean up any existing TC hooks
 	utils.CleanCards()
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -12,6 +12,7 @@ Base URL is whatever host/port `CERBERUS_HTTP_ADDR` binds to (default `http://12
 | `GET /api/v1/devices` | Array of full per-MAC `DeviceInfo`-compatible objects (JSON-tagged fields only). |
 | `GET /api/v1/alerts` | Array of recent rule-based `AlertEvent` objects (threshold monitor). |
 | `GET /api/v1/anomalies` | Single **anomaly snapshot** object: model status, scores, last features, recent alerts with `summary` (plain) and `detail` (technical), `last_summary` / `last_summary_detail` / `last_contributions`, etc. |
+| `GET /api/v1/version` | `{ "commit": "<short-sha>", "date": "<RFC3339>" }` build metadata stamped at compile time via `-ldflags -X`. Both fields are `"unknown"` for builds without git or ldflags. |
 
 Errors: non-GET returns **405** with plain text body `method not allowed`.
 
@@ -19,7 +20,7 @@ Errors: non-GET returns **405** with plain text body `method not allowed`.
 
 | Path | Description |
 |------|-------------|
-| `GET /metrics` | Prometheus text exposition format; scrapes monitor packet counters and related gauges/counters. |
+| `GET /metrics` | Prometheus text exposition format; scrapes monitor packet counters and related gauges/counters. Includes `cerberus_build_info{commit="…",date="…"} 1` for build provenance. |
 
 ## Static assets (Control Room)
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/zrougamed/cerberus/internal/models"
 	"github.com/zrougamed/cerberus/internal/monitor"
+	"github.com/zrougamed/cerberus/internal/version"
 )
 
 //go:embed web/*
@@ -32,6 +33,7 @@ func (s *Server) Handler() (http.Handler, error) {
 	mux.HandleFunc("/api/v1/devices", s.handleDevices)
 	mux.HandleFunc("/api/v1/alerts", s.handleAlerts)
 	mux.HandleFunc("/api/v1/anomalies", s.handleAnomalies)
+	mux.HandleFunc("/api/v1/version", s.handleVersion)
 	mux.HandleFunc("/metrics", s.handleMetrics)
 
 	staticSub, err := fs.Sub(webFS, "web")
@@ -190,6 +192,14 @@ func (s *Server) handleAnomalies(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, s.monitor.GetAnomalySnapshot())
 }
 
+func (s *Server) handleVersion(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	writeJSON(w, http.StatusOK, version.Get())
+}
+
 func (s *Server) handleMetrics(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
@@ -200,6 +210,11 @@ func (s *Server) handleMetrics(w http.ResponseWriter, r *http.Request) {
 	pkt := s.monitor.SnapshotPacketStats()
 	w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
 	w.WriteHeader(http.StatusOK)
+
+	v := version.Get()
+	fmt.Fprintln(w, "# HELP cerberus_build_info Build metadata (commit, build date). Always 1.")
+	fmt.Fprintln(w, "# TYPE cerberus_build_info gauge")
+	fmt.Fprintf(w, "cerberus_build_info{commit=\"%s\",date=\"%s\"} 1\n\n", escapeLabelValue(v.Commit), escapeLabelValue(v.Date))
 
 	fmt.Fprintln(w, "# HELP cerberus_packets_total Total observed packets by protocol.")
 	fmt.Fprintln(w, "# TYPE cerberus_packets_total counter")

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/zrougamed/cerberus/internal/models"
 	"github.com/zrougamed/cerberus/internal/monitor"
+	"github.com/zrougamed/cerberus/internal/version"
 )
 
 func TestTopMapOrdersAndLimits(t *testing.T) {
@@ -93,6 +94,7 @@ func TestMetricsEndpointIncludesCoreCounters(t *testing.T) {
 
 	body := rr.Body.String()
 	mustContain := []string{
+		`cerberus_build_info{commit=`,
 		`cerberus_packets_total{protocol="total"} 12`,
 		`cerberus_packets_total{protocol="dns"} 4`,
 		`cerberus_devices_total 1`,
@@ -170,6 +172,41 @@ func TestAlertsEndpointReturnsRecentAlertsFirst(t *testing.T) {
 		if out[i-1].ObservedAt.Before(out[i].ObservedAt) {
 			t.Fatalf("expected alerts in descending order by observed_at")
 		}
+	}
+}
+
+func TestVersionEndpointReturnsBuildInfo(t *testing.T) {
+	prevCommit, prevDate := version.Commit, version.Date
+	version.Commit = "abc1234"
+	version.Date = "2026-05-14T12:00:00Z"
+	t.Cleanup(func() {
+		version.Commit = prevCommit
+		version.Date = prevDate
+	})
+
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	mon, err := monitor.NewNetworkMonitor(10, dbPath)
+	if err != nil {
+		t.Fatalf("failed to create monitor: %v", err)
+	}
+	defer func() {
+		_ = mon.Close()
+		_ = os.Remove(dbPath)
+	}()
+
+	srv := NewServer(mon)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/version", nil)
+	rr := httptest.NewRecorder()
+	srv.handleVersion(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	var out version.Info
+	if err := json.Unmarshal(rr.Body.Bytes(), &out); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if out.Commit != "abc1234" || out.Date != "2026-05-14T12:00:00Z" {
+		t.Fatalf("unexpected version payload: %+v", out)
 	}
 }
 

--- a/internal/api/web/app.js
+++ b/internal/api/web/app.js
@@ -623,8 +623,29 @@ function setupRouter() {
   });
 }
 
+// Build info only needs to be fetched once — the binary's version is static
+// for the life of the page.
+async function renderBuildInfo() {
+  const el = document.getElementById("build-info");
+  if (!el) return;
+  try {
+    const res = await fetch("/api/v1/version", { headers: { Accept: "application/json" } });
+    if (!res.ok) {
+      el.textContent = "Build: unknown";
+      return;
+    }
+    const v = await res.json();
+    const commit = v && v.commit ? v.commit : "unknown";
+    const date = v && v.date ? v.date : "unknown";
+    el.textContent = `Build: ${commit} (${date})`;
+  } catch {
+    el.textContent = "Build: unknown";
+  }
+}
+
 setupThemeToggle();
 setupPauseToggle();
 setupRouter();
+renderBuildInfo();
 tick();
 setInterval(tick, 3000);

--- a/internal/api/web/index.html
+++ b/internal/api/web/index.html
@@ -17,6 +17,7 @@
       <div>
         <p class="eyebrow">Network Guardian</p>
         <h1>Cerberus Control Room</h1>
+        <p id="build-info" class="build-info muted" title="Build commit and timestamp">Build: …</p>
       </div>
       <div class="header-controls">
         <button id="pause-toggle" class="toggle toggle-pause" type="button" aria-label="Pause live updates">

--- a/internal/api/web/styles.css
+++ b/internal/api/web/styles.css
@@ -68,6 +68,14 @@ body {
   color: var(--text-soft);
 }
 
+.build-info {
+  margin: 4px 0 0;
+  font-size: 0.78rem;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  color: var(--text-soft);
+  letter-spacing: 0.02em;
+}
+
 .header-controls {
   display: flex;
   flex-wrap: wrap;

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,27 @@
+// Package version exposes build metadata populated via -ldflags -X at build time.
+package version
+
+var (
+	// Commit is the short git SHA the binary was built from. Defaults to "unknown"
+	// when the binary is built without ldflags (e.g. plain `go build`).
+	Commit = "unknown"
+
+	// Date is the UTC timestamp the binary was built at, in RFC3339 format.
+	Date = "unknown"
+)
+
+// Info captures the build metadata returned by the version API and shown in the UI.
+type Info struct {
+	Commit string `json:"commit"`
+	Date   string `json:"date"`
+}
+
+// Get returns the current build metadata.
+func Get() Info {
+	return Info{Commit: Commit, Date: Date}
+}
+
+// String renders the version as a single human-readable line for startup logs.
+func String() string {
+	return "commit=" + Commit + " built=" + Date
+}


### PR DESCRIPTION
## Summary

- Stamps short git SHA and build timestamp into the binary via `-ldflags -X` (Makefile + Dockerfile).
- New `/api/v1/version` endpoint returning `{ "commit", "date" }`.
- `cerberus_build_info{commit,date}` gauge in `/metrics` for Prometheus scrape.
- Startup log line `Cerberus commit=<sha> built=<date>` so the running version is visible in `docker logs`.
- Build badge in the Control Room header (`Build: <sha> (<date>)`) fetched once on load.

Falls back to `unknown` for `go build` without ldflags or tarball builds without `.git`, so existing developer workflows still work.

Closes #8.

## Test plan

- [x] `go vet ./...` clean
- [x] `gofmt -s -l .` clean
- [x] `go test ./...` passes (new `TestVersionEndpointReturnsBuildInfo`, existing metrics test extended to assert `cerberus_build_info`)
- [x] Verified `make`-built binary contains stamped commit/date strings (`strings`/`go tool nm`)
- [ ] Manual: `make docker-up` and confirm header shows `Build: <sha>` and `curl /api/v1/version` returns the same SHA